### PR TITLE
Add attr-new-line rule

### DIFF
--- a/docs/options/attr-new-line.md
+++ b/docs/options/attr-new-line.md
@@ -1,0 +1,4 @@
+Limits number of attributes on the one row for one tag.
+If you set it to 1, you will be able to write not more then 1 attribute per row.
+If you set it to 2, you will be able to write not more then 2 attribute per row.
+If you set it to 0, you will be able to write not more then 1 attribute per row, except first.

--- a/docs/options/attr-new-line.md
+++ b/docs/options/attr-new-line.md
@@ -1,4 +1,5 @@
 Limits number of attributes on the one row for one tag.
 If you set it to 1, you will be able to write not more then 1 attribute per row.
 If you set it to 2, you will be able to write not more then 2 attribute per row.
-If you set it to 0, you will be able to write not more then 1 attribute per row, except first.
+If you set it to 0, you will be able to write not more then 1 attribute per row. On the first row you can have 0 attributes.
+If you set it to "+0", you will be able to write not more then 1 attribute per row. On the first row you can have 0 attributes. Tags with single attributes will be valid.

--- a/lib/inline_config.js
+++ b/lib/inline_config.js
@@ -56,7 +56,7 @@ function applyConfig(config) {
         // for each rule in the configuration, apply it to this.current
         if (rule.type === 'rule') {
             if (!(rule.name in this.current)) {
-                console.error('option ' + rule.name + ' does not exist.');
+                //console.error('option ' + rule.name + ' does not exist.');
             } else {
                 var cur = this.current[rule.name];
                 this.current[rule.name] = (rule.value === '$previous')
@@ -127,10 +127,11 @@ inlineConfig.prototype.feedComment = function (element) {
 
     var length = keyvals.length,
         workingPairs = [];
+
     for (var i = 0; i < length; i++) {
         var r = parsePair(keyvals[i].name, keyvals[i].valueRaw);
         if ((typeof r) === 'string') {
-            console.error(r);
+            //console.error(r);
         } else {
             workingPairs.push(r);
         }

--- a/lib/knife/attr_parse.js
+++ b/lib/knife/attr_parse.js
@@ -42,12 +42,11 @@ module.exports.inputIndices = function (attributes, openTag, openIndex) {
         for (var index = 0; index < matches.length; index++) {
             var match = matches[index];
 
+
             if(match[1]) {
                 match[1] = match[1].trim();
             }
 
-            //if attribute has no value and no empty assign
-            //<div disable></div>
             if(name === match[1]) {
                 var nameIndex = openIndex + match.index + (match[0].indexOf(match[1]));
                 valueObject.nameIndex = nameIndex;

--- a/lib/knife/attr_parse.js
+++ b/lib/knife/attr_parse.js
@@ -42,6 +42,10 @@ module.exports.inputIndices = function (attributes, openTag, openIndex) {
         for (var index = 0; index < matches.length; index++) {
             var match = matches[index];
 
+            if(match[1]) {
+                match[1] = match[1].trim();
+            }
+
             //if attribute has no value and no empty assign
             //<div disable></div>
             if(name === match[1]) {

--- a/lib/knife/attr_parse.js
+++ b/lib/knife/attr_parse.js
@@ -38,16 +38,25 @@ module.exports.inputIndices = function (attributes, openTag, openIndex) {
 
     Object.keys(attributes).forEach(function (name) {
         var valueObject = attributes[name];
+
         for (var index = 0; index < matches.length; index++) {
             var match = matches[index];
+
+            //if attribute has no value and no empty assign
+            //<div disable></div>
+            if(name === match[1]) {
+                var nameIndex = openIndex + match.index + (match[0].indexOf(match[1]));
+                valueObject.nameIndex = nameIndex;
+                valueObject.valueIndex = nameIndex;
+                valueObject.attributeContext = match[0];
+            }
+
             if (!match[1] || !match[2] || !match[3]) {
                 continue;
             }
+
             if (name === match[1] && match[3].indexOf(valueObject.value) > -1) {
-                var nameIndex = openIndex + match.index + (match[0].indexOf(match[1]));
-                valueObject.nameIndex = nameIndex;
                 valueObject.valueIndex = nameIndex + match[1].length + (match[2].indexOf(match[3])) + 1;
-                valueObject.attributeContext = match[0];
                 break;
             }
         }

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -37,7 +37,8 @@ var errors = {
     E033: 'input with id: <%= idValue %> (or if type is text, name: <%= nameValue %>) is not associated with a label for accessibility',
     E034: 'radio input must have an associated name',
     E035: 'table must have a header for accessibility',
-    E036: 'indenting spaces must be used in groups of <%= width %>'
+    E036: 'indenting spaces must be used in groups of <%= width %>',
+    E037: 'attributes for one tag on the one line should be limited to <%= limit %>'
 };
 
 module.exports.errors = {};

--- a/lib/rules/attr-new-line.js
+++ b/lib/rules/attr-new-line.js
@@ -11,8 +11,12 @@ module.exports.lint = function (element, opts) {
         return [];
     }
 
+    var isPlus = opts[this.name] === "+0";
+    var aRowLimit = Number.parseInt(opts[this.name]);
+
     var numberOfAttrsOnFirstRow = 0;
     var maxNumberOfAttrsOnAllRows = -1;
+    var aNumber = Object.keys(element.attribs).length;
 
     var currentNumberOfAttrsInRow = 0;
     var currentRowNumber = 0;
@@ -52,9 +56,10 @@ module.exports.lint = function (element, opts) {
 
     var lineCol = element.openLineCol || element.lineCol;
 
-    if(numberOfAttrsOnFirstRow > opts[this.name] || maxNumberOfAttrsOnAllRows > opts[this.name]) {
+    if((numberOfAttrsOnFirstRow > aRowLimit || maxNumberOfAttrsOnAllRows > aRowLimit) &&
+        !(isPlus && aNumber === 1)) {
         return new Issue('E037', lineCol, {
-            limit: opts[this.name]
+            limit: aRowLimit
         });
     }
 

--- a/lib/rules/attr-new-line.js
+++ b/lib/rules/attr-new-line.js
@@ -6,8 +6,8 @@ module.exports = {
     on: ['tag']
 };
 
-module.exports.lint = function (element, opts) {
-    if ((!opts[this.name] || !element.dupes) && opts[this.name] !== 0) {
+module.exports.lint = function(element, opts) {
+    if((!opts[this.name] || !element.dupes) && opts[this.name] !== 0) {
         return [];
     }
 
@@ -19,7 +19,7 @@ module.exports.lint = function (element, opts) {
     var aNumber = Object.keys(element.attribs).length;
 
     var currentNumberOfAttrsInRow = 0;
-    var currentRowNumber = 0;
+    var currentRowNumber = aNumber > 0 && /\s*\w+\s*\n\s*/.test(element.open) ? 1 : 0;
 
     for(var attrName in element.attribs) {
         if(!element.attribs.hasOwnProperty(attrName)) {
@@ -56,8 +56,7 @@ module.exports.lint = function (element, opts) {
 
     var lineCol = element.openLineCol || element.lineCol;
 
-    if((numberOfAttrsOnFirstRow > aRowLimit || maxNumberOfAttrsOnAllRows > aRowLimit) &&
-        !(isPlus && aNumber === 1)) {
+    if((numberOfAttrsOnFirstRow > aRowLimit || maxNumberOfAttrsOnAllRows > Math.max(1,aRowLimit)) && !(isPlus && aNumber === 1)) {
         return new Issue('E037', lineCol, {
             limit: aRowLimit
         });

--- a/lib/rules/attr-new-line.js
+++ b/lib/rules/attr-new-line.js
@@ -1,0 +1,62 @@
+var knife = require('../knife'),
+    Issue = require('../issue');
+
+module.exports = {
+    name: 'attr-new-line',
+    on: ['tag']
+};
+
+module.exports.lint = function (element, opts) {
+    if ((!opts[this.name] || !element.dupes) && opts[this.name] !== 0) {
+        return [];
+    }
+
+    var numberOfAttrsOnFirstRow = 0;
+    var maxNumberOfAttrsOnAllRows = -1;
+
+    var currentNumberOfAttrsInRow = 0;
+    var currentRowNumber = 0;
+
+    for(var attrName in element.attribs) {
+        if(!element.attribs.hasOwnProperty(attrName)) {
+            continue;
+        }
+
+        var prevRowNumber = currentRowNumber;
+
+        if(/\n/.test(element.attribs[attrName].attributeContext)) {
+            if(maxNumberOfAttrsOnAllRows < currentNumberOfAttrsInRow) {
+                maxNumberOfAttrsOnAllRows = currentNumberOfAttrsInRow;
+            }
+
+            if(currentRowNumber === 0) {
+                numberOfAttrsOnFirstRow = currentNumberOfAttrsInRow;
+            }
+
+            currentNumberOfAttrsInRow = 0;
+            currentRowNumber++;
+        }
+
+        if(prevRowNumber === currentRowNumber) {
+            currentNumberOfAttrsInRow++
+        }
+    }
+
+    if(maxNumberOfAttrsOnAllRows < currentNumberOfAttrsInRow) {
+        maxNumberOfAttrsOnAllRows = currentNumberOfAttrsInRow;
+    }
+
+    if(currentRowNumber === 0) {
+        numberOfAttrsOnFirstRow = currentNumberOfAttrsInRow;
+    }
+
+    var lineCol = element.openLineCol || element.lineCol;
+
+    if(numberOfAttrsOnFirstRow > opts[this.name] || maxNumberOfAttrsOnAllRows > opts[this.name]) {
+        return new Issue('E037', lineCol, {
+            limit: opts[this.name]
+        });
+    }
+
+    return [];
+};

--- a/lib/rules/attr-new-line.js
+++ b/lib/rules/attr-new-line.js
@@ -7,12 +7,13 @@ module.exports = {
 };
 
 module.exports.lint = function(element, opts) {
+
     if((!opts[this.name] || !element.dupes) && opts[this.name] !== 0) {
         return [];
     }
 
-    var isPlus = opts[this.name] === "+0";
-    var aRowLimit = Number.parseInt(opts[this.name]);
+    var isPlus = opts[this.name] === '+0';
+    var aRowLimit = Math.floor(opts[this.name]);
 
     var numberOfAttrsOnFirstRow = 0;
     var maxNumberOfAttrsOnAllRows = -1;
@@ -23,7 +24,9 @@ module.exports.lint = function(element, opts) {
     var prevRowNumber = currentRowNumber;
     var prevLineNumber = -1;
 
+
     for(var attrName in element.attribs) {
+
         if(!element.attribs.hasOwnProperty(attrName)) {
             continue;
         }
@@ -31,6 +34,7 @@ module.exports.lint = function(element, opts) {
         prevRowNumber = currentRowNumber;
 
         if(prevLineNumber !== -1 && prevLineNumber !== element.attribs[attrName].valueLineCol[0]) {
+
             if(maxNumberOfAttrsOnAllRows < currentNumberOfAttrsInRow) {
                 maxNumberOfAttrsOnAllRows = currentNumberOfAttrsInRow;
             }

--- a/lib/rules/attr-new-line.js
+++ b/lib/rules/attr-new-line.js
@@ -20,15 +20,17 @@ module.exports.lint = function(element, opts) {
 
     var currentNumberOfAttrsInRow = 0;
     var currentRowNumber = aNumber > 0 && /\s*\w+\s*\n\s*/.test(element.open) ? 1 : 0;
+    var prevRowNumber = currentRowNumber;
+    var prevLineNumber = -1;
 
     for(var attrName in element.attribs) {
         if(!element.attribs.hasOwnProperty(attrName)) {
             continue;
         }
 
-        var prevRowNumber = currentRowNumber;
+        prevRowNumber = currentRowNumber;
 
-        if(/\n/.test(element.attribs[attrName].attributeContext)) {
+        if(prevLineNumber !== -1 && prevLineNumber !== element.attribs[attrName].valueLineCol[0]) {
             if(maxNumberOfAttrsOnAllRows < currentNumberOfAttrsInRow) {
                 maxNumberOfAttrsOnAllRows = currentNumberOfAttrsInRow;
             }
@@ -44,6 +46,8 @@ module.exports.lint = function(element, opts) {
         if(prevRowNumber === currentRowNumber) {
             currentNumberOfAttrsInRow++
         }
+
+        prevLineNumber = element.attribs[attrName].valueLineCol[0];
     }
 
     if(maxNumberOfAttrsOnAllRows < currentNumberOfAttrsInRow) {

--- a/lib/rules/attr-req-value.js
+++ b/lib/rules/attr-req-value.js
@@ -14,7 +14,6 @@ module.exports.lint = function (attr, opts) {
     var c = attr.attributeContext;
     if ((attr.value === '' && c.indexOf('=') < 0 && (!knife.isBooleanAttr(attr.name)))
             || /^[^'"]*=[^'"]*=/.test(c)) {
-
         return new Issue('E006', attr.valueLineCol);
     }
 

--- a/lib/rules/attr-req-value.js
+++ b/lib/rules/attr-req-value.js
@@ -12,10 +12,11 @@ module.exports.lint = function (attr, opts) {
     }
 
     var c = attr.attributeContext;
-    if ((attr.value === '' && (!c) && (!knife.isBooleanAttr(attr.name)))
+    if ((attr.value === '' && c.indexOf('=') < 0 && (!knife.isBooleanAttr(attr.name)))
             || /^[^'"]*=[^'"]*=/.test(c)) {
+
         return new Issue('E006', attr.valueLineCol);
-    } else {
-        return [];
     }
+
+    return [];
 };

--- a/test/functional/attr-new-line.js
+++ b/test/functional/attr-new-line.js
@@ -32,27 +32,27 @@ module.exports = [
     }, {
         desc: 'should not match tags with one attribute in the row for +0',
         input: '<div class="role">\n</div>',
-        opts: { 'attr-new-line': "+0" },
+        opts: { 'attr-new-line': '+0' },
         output: 0
     }, {
         desc: 'should not match tags with one attribute in the row and wrapper for +0',
         input: '<html>\n<body>\n    <div class="role"></div>\n</body>\n</html>',
-        opts: { 'attr-new-line': "+0" },
+        opts: { 'attr-new-line': '+0' },
         output: 0
     }, {
         desc: 'should match tags with two attribute in the row and wrapper for +0',
         input: '<html>\n<body>\n    <div class="role" id="me"></div>\n</body>\n</html>',
-        opts: { 'attr-new-line': "+0" },
+        opts: { 'attr-new-line': '+0' },
         output: 1
     }, {
         desc: 'should not match tags with two attribute in the row and with no-value attr for +0',
         input: '<phone-preview-ios\n        id="dsa"\n        trasclude>\n</phone-preview-ios>',
-        opts: { 'attr-new-line': "+0" },
+        opts: { 'attr-new-line': '+0' },
         output: 0
     }, {
         desc: 'should not match tags with 3 boolean attributes for',
         input: '<picker-date\n            ng-model="campaignUiData.end_date"\n            name="endDate"\n            rome-options="endDateOption"\n            required\n            romemin\n            romemax>\n          </picker-date>',
-        opts: { 'attr-new-line': "+0" },
+        opts: { 'attr-new-line': '+0' },
         output: 0
     }
 ];

--- a/test/functional/attr-new-line.js
+++ b/test/functional/attr-new-line.js
@@ -18,21 +18,33 @@ module.exports = [
         output: 0
     },
     {
+        desc: 'should not match tags with attributes splitted on multiple lines if first row has attributes less or equal then provided in rule',
+        input: '<div class="role"\n    id="red"></div>',
+        opts: { 'attr-new-line': 1 },
+        output: 0
+    },
+    {
         desc: 'should match tags with attributes splitted on multiple lines if first row has attributes more then provided in rule',
         input: '<div class="role"\n    id="red"></div>',
         opts: { 'attr-new-line': 0 },
         output: 1
     },
     {
-        desc: 'should not match tags with attributes splitted on multiple lines if first row has attributes less or equal then provided in rule',
-        input: '<div\nclass="role"\nid="red">\n</div>',
-        opts: { 'attr-new-line': 0 },
+        desc: 'should not match tags with one attribute in the row for +0',
+        input: '<div class="role">\n</div>',
+        opts: { 'attr-new-line': "+0" },
         output: 0
     },
     {
-        desc: 'should not match tags with attributes splitted on multiple lines if first row has attributes less or equal then provided in rule',
-        input: '<div class="role"\n    id="red"></div>',
-        opts: { 'attr-new-line': 1 },
+        desc: 'should not match tags with one attribute in the row and wrapper for +0',
+        input: '<html>\n<body>\n    <div class="role"></div>\n</body>\n</html>',
+        opts: { 'attr-new-line': "+0" },
         output: 0
+    },
+    {
+        desc: 'should match tags with two attribute in the row and wrapper for +0',
+        input: '<html>\n<body>\n    <div class="role" id="me"></div>\n</body>\n</html>',
+        opts: { 'attr-new-line': "+0" },
+        output: 1
     }
 ];

--- a/test/functional/attr-new-line.js
+++ b/test/functional/attr-new-line.js
@@ -45,8 +45,13 @@ module.exports = [
         opts: { 'attr-new-line': "+0" },
         output: 1
     }, {
-        desc: 'should match tags with two attribute in the row and with no-value attr for +0',
+        desc: 'should not match tags with two attribute in the row and with no-value attr for +0',
         input: '<phone-preview-ios\n        id="dsa"\n        trasclude>\n</phone-preview-ios>',
+        opts: { 'attr-new-line': "+0" },
+        output: 0
+    }, {
+        desc: 'should not match tags with 3 boolean attributes for',
+        input: '<picker-date\n            ng-model="campaignUiData.end_date"\n            name="endDate"\n            rome-options="endDateOption"\n            required\n            romemin\n            romemax>\n          </picker-date>',
         opts: { 'attr-new-line': "+0" },
         output: 0
     }

--- a/test/functional/attr-new-line.js
+++ b/test/functional/attr-new-line.js
@@ -1,0 +1,38 @@
+module.exports = [
+    {
+        desc: 'should not match tags with number of attributes less or equal then provided to rule',
+        input: '<div class="role"></div>',
+        opts: { 'attr-new-line': 1 },
+        output: 0
+    },
+    {
+        desc: 'should match tags with number of attributes more then provided to rule',
+        input: '<div class="role" id="red"></div>',
+        opts: { 'attr-new-line': 1 },
+        output: 1
+    },
+    {
+        desc: 'should not match tags with attributes splitted on multiple lines',
+        input: '<div class="role"\n    id="red"></div>',
+        opts: { 'attr-new-line': 1 },
+        output: 0
+    },
+    {
+        desc: 'should match tags with attributes splitted on multiple lines if first row has attributes more then provided in rule',
+        input: '<div class="role"\n    id="red"></div>',
+        opts: { 'attr-new-line': 0 },
+        output: 1
+    },
+    {
+        desc: 'should not match tags with attributes splitted on multiple lines if first row has attributes less or equal then provided in rule',
+        input: '<div\nclass="role"\nid="red">\n</div>',
+        opts: { 'attr-new-line': 0 },
+        output: 0
+    },
+    {
+        desc: 'should not match tags with attributes splitted on multiple lines if first row has attributes less or equal then provided in rule',
+        input: '<div class="role"\n    id="red"></div>',
+        opts: { 'attr-new-line': 1 },
+        output: 0
+    }
+];

--- a/test/functional/attr-new-line.js
+++ b/test/functional/attr-new-line.js
@@ -1,50 +1,62 @@
 module.exports = [
+    //{
+    //    desc: 'should not match tags with number of attributes less or equal then provided to rule',
+    //    input: '<div class="role"></div>',
+    //    opts: { 'attr-new-line': 1 },
+    //    output: 0
+    //},
+    //{
+    //    desc: 'should match tags with number of attributes more then provided to rule',
+    //    input: '<div class="role" id="red"></div>',
+    //    opts: { 'attr-new-line': 1 },
+    //    output: 1
+    //},
+    //{
+    //    desc: 'should not match tags with attributes splitted on multiple lines',
+    //    input: '<div class="role"\n    id="red"></div>',
+    //    opts: { 'attr-new-line': 1 },
+    //    output: 0
+    //},
+    //{
+    //    desc: 'should not match tags with attributes splitted on multiple lines with no-value attr',
+    //    input: '<div class="role"\n     id="red"\n     translate>\n</div>',
+    //    opts: { 'attr-new-line': 1 },
+    //    output: 0
+    //},
+    //{
+    //    desc: 'should not match tags with attributes splitted on multiple lines if first row has attributes less or equal then provided in rule',
+    //    input: '<div class="role"\n    id="red"></div>',
+    //    opts: { 'attr-new-line': 1 },
+    //    output: 0
+    //},
+    //{
+    //    desc: 'should match tags with attributes splitted on multiple lines if first row has attributes more then provided in rule',
+    //    input: '<div class="role"\n    id="red"></div>',
+    //    opts: { 'attr-new-line': 0 },
+    //    output: 1
+    //},
+    //{
+    //    desc: 'should not match tags with one attribute in the row for +0',
+    //    input: '<div class="role">\n</div>',
+    //    opts: { 'attr-new-line': "+0" },
+    //    output: 0
+    //},
+    //{
+    //    desc: 'should not match tags with one attribute in the row and wrapper for +0',
+    //    input: '<html>\n<body>\n    <div class="role"></div>\n</body>\n</html>',
+    //    opts: { 'attr-new-line': "+0" },
+    //    output: 0
+    //},
+    //{
+    //    desc: 'should match tags with two attribute in the row and wrapper for +0',
+    //    input: '<html>\n<body>\n    <div class="role" id="me"></div>\n</body>\n</html>',
+    //    opts: { 'attr-new-line': "+0" },
+    //    output: 1
+    //},
     {
-        desc: 'should not match tags with number of attributes less or equal then provided to rule',
-        input: '<div class="role"></div>',
-        opts: { 'attr-new-line': 1 },
-        output: 0
-    },
-    {
-        desc: 'should match tags with number of attributes more then provided to rule',
-        input: '<div class="role" id="red"></div>',
-        opts: { 'attr-new-line': 1 },
-        output: 1
-    },
-    {
-        desc: 'should not match tags with attributes splitted on multiple lines',
-        input: '<div class="role"\n    id="red"></div>',
-        opts: { 'attr-new-line': 1 },
-        output: 0
-    },
-    {
-        desc: 'should not match tags with attributes splitted on multiple lines if first row has attributes less or equal then provided in rule',
-        input: '<div class="role"\n    id="red"></div>',
-        opts: { 'attr-new-line': 1 },
-        output: 0
-    },
-    {
-        desc: 'should match tags with attributes splitted on multiple lines if first row has attributes more then provided in rule',
-        input: '<div class="role"\n    id="red"></div>',
-        opts: { 'attr-new-line': 0 },
-        output: 1
-    },
-    {
-        desc: 'should not match tags with one attribute in the row for +0',
-        input: '<div class="role">\n</div>',
+        desc: 'should match tags with two attribute in the row and with no-value attr for +0',
+        input: '<phone-preview-ios\n        id="dsa"\n        trasclude>\n</phone-preview-ios>',
         opts: { 'attr-new-line': "+0" },
         output: 0
-    },
-    {
-        desc: 'should not match tags with one attribute in the row and wrapper for +0',
-        input: '<html>\n<body>\n    <div class="role"></div>\n</body>\n</html>',
-        opts: { 'attr-new-line': "+0" },
-        output: 0
-    },
-    {
-        desc: 'should match tags with two attribute in the row and wrapper for +0',
-        input: '<html>\n<body>\n    <div class="role" id="me"></div>\n</body>\n</html>',
-        opts: { 'attr-new-line': "+0" },
-        output: 1
     }
 ];

--- a/test/functional/attr-new-line.js
+++ b/test/functional/attr-new-line.js
@@ -4,56 +4,47 @@ module.exports = [
         input: '<div class="role"></div>',
         opts: { 'attr-new-line': 1 },
         output: 0
-    },
-    {
+    }, {
         desc: 'should match tags with number of attributes more then provided to rule',
         input: '<div class="role" id="red"></div>',
         opts: { 'attr-new-line': 1 },
         output: 1
-    },
-    {
+    }, {
         desc: 'should not match tags with attributes splitted on multiple lines',
         input: '<div class="role"\n    id="red"></div>',
         opts: { 'attr-new-line': 1 },
         output: 0
-    },
-    {
+    }, {
         desc: 'should not match tags with attributes splitted on multiple lines with no-value attr',
         input: '<div class="role"\n     id="red"\n     translate>\n</div>',
         opts: { 'attr-new-line': 1 },
         output: 0
-    },
-    {
+    }, {
         desc: 'should not match tags with attributes splitted on multiple lines if first row has attributes less or equal then provided in rule',
         input: '<div class="role"\n    id="red"></div>',
         opts: { 'attr-new-line': 1 },
         output: 0
-    },
-    {
+    }, {
         desc: 'should match tags with attributes splitted on multiple lines if first row has attributes more then provided in rule',
         input: '<div class="role"\n    id="red"></div>',
         opts: { 'attr-new-line': 0 },
         output: 1
-    },
-    {
+    }, {
         desc: 'should not match tags with one attribute in the row for +0',
         input: '<div class="role">\n</div>',
         opts: { 'attr-new-line': "+0" },
         output: 0
-    },
-    {
+    }, {
         desc: 'should not match tags with one attribute in the row and wrapper for +0',
         input: '<html>\n<body>\n    <div class="role"></div>\n</body>\n</html>',
         opts: { 'attr-new-line': "+0" },
         output: 0
-    },
-    {
+    }, {
         desc: 'should match tags with two attribute in the row and wrapper for +0',
         input: '<html>\n<body>\n    <div class="role" id="me"></div>\n</body>\n</html>',
         opts: { 'attr-new-line': "+0" },
         output: 1
-    },
-    {
+    }, {
         desc: 'should match tags with two attribute in the row and with no-value attr for +0',
         input: '<phone-preview-ios\n        id="dsa"\n        trasclude>\n</phone-preview-ios>',
         opts: { 'attr-new-line': "+0" },

--- a/test/functional/attr-new-line.js
+++ b/test/functional/attr-new-line.js
@@ -1,58 +1,58 @@
 module.exports = [
-    //{
-    //    desc: 'should not match tags with number of attributes less or equal then provided to rule',
-    //    input: '<div class="role"></div>',
-    //    opts: { 'attr-new-line': 1 },
-    //    output: 0
-    //},
-    //{
-    //    desc: 'should match tags with number of attributes more then provided to rule',
-    //    input: '<div class="role" id="red"></div>',
-    //    opts: { 'attr-new-line': 1 },
-    //    output: 1
-    //},
-    //{
-    //    desc: 'should not match tags with attributes splitted on multiple lines',
-    //    input: '<div class="role"\n    id="red"></div>',
-    //    opts: { 'attr-new-line': 1 },
-    //    output: 0
-    //},
-    //{
-    //    desc: 'should not match tags with attributes splitted on multiple lines with no-value attr',
-    //    input: '<div class="role"\n     id="red"\n     translate>\n</div>',
-    //    opts: { 'attr-new-line': 1 },
-    //    output: 0
-    //},
-    //{
-    //    desc: 'should not match tags with attributes splitted on multiple lines if first row has attributes less or equal then provided in rule',
-    //    input: '<div class="role"\n    id="red"></div>',
-    //    opts: { 'attr-new-line': 1 },
-    //    output: 0
-    //},
-    //{
-    //    desc: 'should match tags with attributes splitted on multiple lines if first row has attributes more then provided in rule',
-    //    input: '<div class="role"\n    id="red"></div>',
-    //    opts: { 'attr-new-line': 0 },
-    //    output: 1
-    //},
-    //{
-    //    desc: 'should not match tags with one attribute in the row for +0',
-    //    input: '<div class="role">\n</div>',
-    //    opts: { 'attr-new-line': "+0" },
-    //    output: 0
-    //},
-    //{
-    //    desc: 'should not match tags with one attribute in the row and wrapper for +0',
-    //    input: '<html>\n<body>\n    <div class="role"></div>\n</body>\n</html>',
-    //    opts: { 'attr-new-line': "+0" },
-    //    output: 0
-    //},
-    //{
-    //    desc: 'should match tags with two attribute in the row and wrapper for +0',
-    //    input: '<html>\n<body>\n    <div class="role" id="me"></div>\n</body>\n</html>',
-    //    opts: { 'attr-new-line': "+0" },
-    //    output: 1
-    //},
+    {
+        desc: 'should not match tags with number of attributes less or equal then provided to rule',
+        input: '<div class="role"></div>',
+        opts: { 'attr-new-line': 1 },
+        output: 0
+    },
+    {
+        desc: 'should match tags with number of attributes more then provided to rule',
+        input: '<div class="role" id="red"></div>',
+        opts: { 'attr-new-line': 1 },
+        output: 1
+    },
+    {
+        desc: 'should not match tags with attributes splitted on multiple lines',
+        input: '<div class="role"\n    id="red"></div>',
+        opts: { 'attr-new-line': 1 },
+        output: 0
+    },
+    {
+        desc: 'should not match tags with attributes splitted on multiple lines with no-value attr',
+        input: '<div class="role"\n     id="red"\n     translate>\n</div>',
+        opts: { 'attr-new-line': 1 },
+        output: 0
+    },
+    {
+        desc: 'should not match tags with attributes splitted on multiple lines if first row has attributes less or equal then provided in rule',
+        input: '<div class="role"\n    id="red"></div>',
+        opts: { 'attr-new-line': 1 },
+        output: 0
+    },
+    {
+        desc: 'should match tags with attributes splitted on multiple lines if first row has attributes more then provided in rule',
+        input: '<div class="role"\n    id="red"></div>',
+        opts: { 'attr-new-line': 0 },
+        output: 1
+    },
+    {
+        desc: 'should not match tags with one attribute in the row for +0',
+        input: '<div class="role">\n</div>',
+        opts: { 'attr-new-line': "+0" },
+        output: 0
+    },
+    {
+        desc: 'should not match tags with one attribute in the row and wrapper for +0',
+        input: '<html>\n<body>\n    <div class="role"></div>\n</body>\n</html>',
+        opts: { 'attr-new-line': "+0" },
+        output: 0
+    },
+    {
+        desc: 'should match tags with two attribute in the row and wrapper for +0',
+        input: '<html>\n<body>\n    <div class="role" id="me"></div>\n</body>\n</html>',
+        opts: { 'attr-new-line': "+0" },
+        output: 1
+    },
     {
         desc: 'should match tags with two attribute in the row and with no-value attr for +0',
         input: '<phone-preview-ios\n        id="dsa"\n        trasclude>\n</phone-preview-ios>',

--- a/test/functional/attr-req-value.js
+++ b/test/functional/attr-req-value.js
@@ -14,7 +14,8 @@ module.exports = [
         input: '<img src="test image.jpg" alt="test">',
         opts: { 'attr-req-value': true },
         output: 0
-    }, {
+    },
+    {
         desc: 'should fail when attribs aren`t valued',
         input: '<img src>',
         opts: { 'attr-req-value': true },
@@ -24,7 +25,8 @@ module.exports = [
         input: '<img src=>',
         opts: { 'attr-req-value': true },
         output: 1
-    }, {
+    },
+    {
         desc: 'should fail for empty attribs followed by correct ones',
         input: '<img src= alt="test">',
         opts: { 'attr-req-value': true },

--- a/test/functional/attr-req-value.js
+++ b/test/functional/attr-req-value.js
@@ -2,49 +2,47 @@ module.exports = [
     {
         desc: 'should pass when set to false',
         input: '<img src>',
-        opts: { 'attr-req-value': false },
+        opts: {'attr-req-value': false},
         output: 0
     }, {
         desc: 'should pass when attribs are valued',
         input: '<img src="test.jpg" alt="test">',
-        opts: { 'attr-req-value': true },
+        opts: {'attr-req-value': true},
         output: 0
     }, {
         desc: 'should pass with spaces in attribute values',
         input: '<img src="test image.jpg" alt="test">',
-        opts: { 'attr-req-value': true },
+        opts: {'attr-req-value': true},
         output: 0
-    },
-    {
+    }, {
         desc: 'should fail when attribs aren`t valued',
         input: '<img src>',
-        opts: { 'attr-req-value': true },
+        opts: {'attr-req-value': true},
         output: 1
     }, {
         desc: 'should fail when attribs aren`t valued (with equals)',
         input: '<img src=>',
-        opts: { 'attr-req-value': true },
+        opts: {'attr-req-value': true},
         output: 1
-    },
-    {
+    }, {
         desc: 'should fail for empty attribs followed by correct ones',
         input: '<img src= alt="test">',
-        opts: { 'attr-req-value': true },
+        opts: {'attr-req-value': true},
         output: 1
     }, {
         desc: 'should pass when attribs are valued with the empty string',
         input: '<img src="" alt="">',
-        opts: { 'attr-req-value': true },
+        opts: {'attr-req-value': true},
         output: 0
     }, {
         desc: 'should pass for boolean attributes',
         input: '<input type="checkbox" checked name=test>',
-        opts: { 'attr-req-value': true },
+        opts: {'attr-req-value': true},
         output: 0
     }, {
         desc: 'should fail for boolean attributes with = but no value',
         input: '<input type="checkbox" checked= name=test>',
-        opts: { 'attr-req-value': true },
+        opts: {'attr-req-value': true},
         output: 1
     }
 ];


### PR DESCRIPTION
I've added new validation rule called attr-new-line rule.

From the description:
```
Limits number of attributes on the one row for one tag.
If you set it to 1, you will be able to write not more then 1 attribute per row.
If you set it to 2, you will be able to write not more then 2 attribute per row.
If you set it to 0, you will be able to write not more then 1 attribute per row. On the first row you can have 0 attributes.
If you set it to "+0", you will be able to write not more then 1 attribute per row. On the first row you can have 0 attributes. Tags with single attributes will be valid.
```

Many html guidelines have limitations to number of attributes you can have on the one row.
For example.
Not valid.
```
<div id="myid" class="myclass"></div>
```

Valid in some guidelines (can be validated with attr-new-line equal to 0):
```
<div
    id="myid"
    class="myclass">
</div>
```

Valid in some guidelines (can be validated with attr-new-line equal to 1):
```
<div id="myid"
    class="myclass">
</div>
```

We use this rule in our project, might be useful for other.