### PR TITLE
Add rule name to issues for a better output

### DIFF
--- a/lib/knife/apply_rules.js
+++ b/lib/knife/apply_rules.js
@@ -1,5 +1,18 @@
 var lodash = require('lodash');
 
+function addRuleToIssue (issue, ruleName) {
+
+    if (Array.isArray(issue)) {
+        issue.forEach(function (issue) {
+            addRuleToIssue(issue, ruleName);
+        });
+    }
+    else {
+        issue.rule = issue.rule || ruleName;
+    }
+
+}
+
 module.exports = {
     applyRules: function(rules, element, opts) {
         if (!rules) {
@@ -9,15 +22,7 @@ module.exports = {
         return lodash.flatten(rules.map(function(rule) {
             var issues = rule.lint.call(rule, element, opts);
 
-            // apparently we can also get an issue directly, instead of an array of issues
-            if (!Array.isArray(issues)) {
-                issues.rule = rule.name;
-            }
-            else {
-                issues.forEach(function (issue) {
-                    issue.rule = rule.name;
-                });
-            }
+            addRuleToIssue(issues, rule.name);
 
             return issues;
         }));

--- a/lib/knife/apply_rules.js
+++ b/lib/knife/apply_rules.js
@@ -7,7 +7,20 @@ module.exports = {
         }
 
         return lodash.flatten(rules.map(function(rule) {
-            return rule.lint.call(rule, element, opts);
+            var issues = rule.lint.call(rule, element, opts);
+
+            // apparently we can also get an issue directly, instead of an array of issues
+            if (!Array.isArray(issues)) {
+                issues.rule = rule.name;
+            }
+            else {
+                issues.forEach(function (issue) {
+                    issue.rule = rule.name;
+                });
+            }
+
+            return issues;
         }));
+
     }
 };


### PR DESCRIPTION
Added functionality to add the rule name to the issues when called through `applyRules`. This provides a better linting result as the offending rule is clearly visible.

The property `rule` is named that way to be consistent with `jscs`.

Could not run the test set, got a weird error. Maybe a windows/mac thing or so, I'm on windows.