### PR TITLE
Break on any amount of whitespace instead of on one space only

### DIFF
--- a/lib/rules/id-class-style.js
+++ b/lib/rules/id-class-style.js
@@ -21,7 +21,7 @@ module.exports.lint = function (attr, opts) {
     if (ignore) { v = v.replace(new RegExp(ignore), '\u0001'); }
 
     var verify = knife.getFormatTest(format);
-    var cssclasses = v.split(' ');
+    var cssclasses = v.split(/\s+/);
 
     return lodash.flatten(cssclasses.map(function(c) {
         return (c.indexOf('\u0001') !== -1 || verify(c)) ? [] :


### PR DESCRIPTION
This would fail the rule `id-class-style` even though the classes defined are fine:

```
<span class="booger   biz"></span>
```

Updated the `.split` to break on all whitespace instead of on single spaces only.