### PR TITLE
Upgrade to lodash 4

### DIFF
--- a/lib/knife/apply_rules.js
+++ b/lib/knife/apply_rules.js
@@ -19,7 +19,7 @@ module.exports = {
             return [];
         }
 
-        return lodash.flatten(rules.map(function(rule) {
+        return lodash.flattenDeep(rules.map(function(rule) {
             var issues = rule.lint.call(rule, element, opts);
 
             addRuleToIssue(issues, rule.name);

--- a/lib/knife/is_labeable.js
+++ b/lib/knife/is_labeable.js
@@ -19,7 +19,7 @@ var elems = [
  * @returns {Boolean} whether or not `ele` is labelable
  */
 module.exports.isLabeable = function (ele) {
-    if (ele.type !== 'tag' || !lodash.contains(elems, ele.name)) {
+    if (ele.type !== 'tag' || !lodash.includes(elems, ele.name)) {
         // element isn't a tag or isn't a labeable element
         return false;
     }

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -52,7 +52,7 @@ Linter.prototype.lint = function (html) {
     this.inlineConfig.clear();
 
     if (maxerr >= 0) {
-        issues = lodash.first(issues, maxerr);
+        issues = lodash.take(issues, maxerr);
     }
 
     return Promise.all(issues)

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -57,14 +57,14 @@ Linter.prototype.lint = function (html) {
 
     return Promise.all(issues)
         .then(function (resolved) {
-            return lodash.flatten(resolved);
+            return lodash.flattenDeep(resolved);
         });
 };
 Linter.prototype.lint = Promise.nodeify(Linter.prototype.lint);
 
 Linter.getOptions = function (args) {
     var optList = Array.prototype.slice.call(args, 1);
-    optList = lodash.flatten(optList);
+    optList = lodash.flattenDeep(optList);
 
     optList.unshift('default');
 
@@ -99,7 +99,7 @@ Linter.prototype.resetRules = function (opts) {
         }
     });
 
-    return lodash.flatten(issues);
+    return lodash.flattenDeep(issues);
 };
 
 Linter.prototype.setupInlineConfigs = function (dom) {

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -53,7 +53,7 @@ lodash.forOwn(errors, function (format, code) {
 module.exports.renderMsg = function (code, data) {
     var format = errors[code];
 
-    return lodash.template(format, data);
+    return lodash.template(format)(data);
 };
 
 module.exports.renderIssue = function (issue) {

--- a/lib/rules/class-style.js
+++ b/lib/rules/class-style.js
@@ -23,7 +23,7 @@ module.exports.lint = function (attr, opts) {
     var verify = knife.getFormatTest(format);
     var cssclasses = v.split(/\s+/);
 
-    return lodash.flatten(cssclasses.map(function(c) {
+    return lodash.flattenDeep(cssclasses.map(function(c) {
         return (c.indexOf('\u0001') !== -1 || verify(c)) ? [] :
             new Issue('E011', attr.valueLineCol, { format: format, 'class': c });
     }));

--- a/lib/rules/dom.js
+++ b/lib/rules/dom.js
@@ -32,5 +32,5 @@ module.exports.lint = function(dom, opts, inlineConfigs) {
     };
 
     var issues = dom.length ? dom.map(getIssues) : [];
-    return lodash.flatten(issues);
+    return lodash.flattenDeep(issues);
 };

--- a/lib/rules/line.js
+++ b/lib/rules/line.js
@@ -10,7 +10,7 @@ module.exports.lint = function(lines, opts, inlineConfigs) {
     var subs = this.subscribers;
     // use the opts as our base, and build from them.
     inlineConfigs.reset(opts);
-    return lodash.flatten(lines.map(function (line, index) {
+    return lodash.flattenDeep(lines.map(function (line, index) {
         /*
          * Right now, if the config is on a line, that whole line is
          * given the new configuration. This is not great in theory,

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "bulk-require": "^0.2.1",
     "htmlparser2": "^3.7.3",
-    "lodash": "^2.4.1",
+    "lodash": "^4.3.0",
     "promise": "^6.0.1"
   },
   "browserify": {


### PR DESCRIPTION
Upgrades package dependency to lodash 4 and updates code to deal with breaking changes between lodash 2 and lodash 4:

* Change `flatten` to `flattenDeep`
* Call the return value of `template()` with `data`
* Use `includes` instead of `contains`
* Use `take` instead of `first` with a size

For the curious, the motivation here is that lodash <4 has a bug which breaks browserify-packaged code running in a web worker, which happens to be the exact environment in which I’d like to be running `htmllint`.