### PR TITLE
Add 'line-length' rule

### DIFF
--- a/lib/messages.js
+++ b/lib/messages.js
@@ -40,7 +40,8 @@ var errors = {
     E036: 'indenting spaces must be used in groups of <%= width %>',
     E037: 'attributes for one tag on the one line should be limited to <%= limit %>',
     E038: 'lang attribute <%= lang %> is not valid',
-    E039: 'lang attribute <%= lang %> in not properly capitalized'
+    E039: 'lang attribute <%= lang %> in not properly capitalized',
+    E040: 'line length should not exceed <%= maxlength %> characters (current: <%= length %>)'
 };
 
 module.exports.errors = {};

--- a/lib/rules/line-length.js
+++ b/lib/rules/line-length.js
@@ -1,0 +1,34 @@
+var Issue = require('../issue');
+
+module.exports = {
+  name: 'line-length',
+  on: ['line']
+};
+
+module.exports.lint = function (line, opts) {
+  var maxLength = opts[this.name];
+  var ignoreRegExpString = opts[this.name + '-ignore-regex'];
+  var lineText;
+  var len;
+  var pos;
+
+  if (!maxLength) {
+    return [];
+  }
+
+  lineText = line.line;
+
+  if (ignoreRegExpString && (new RegExp(ignoreRegExpString, 'g')).test(lineText)) {
+    return [];
+  }
+
+  len = lineText.length - 1;
+
+  if (len <= maxLength) {
+    return [];
+  }
+
+  pos = [line.row, len + 1];
+
+  return new Issue('E040', pos, { maxlength: maxLength, length: len });
+};

--- a/test/functional/line-length.js
+++ b/test/functional/line-length.js
@@ -1,0 +1,23 @@
+module.exports = [
+  {
+    desc: 'should pass when line length not exceeds the maximum value',
+    input: '1234',
+    opts: { 'line-length': 5 },
+    output: 0
+  }, {
+    desc: 'should pass when line length equals to the maximum value',
+    input: '12345',
+    opts: { 'line-length': 5 },
+    output: 0
+  }, {
+    desc: 'should fail when line length exceeds the maximum value',
+    input: '123456',
+    opts: { 'line-length': 5 },
+    output: 1
+  }, {
+    desc: 'should pass when line length matches ignore-regex',
+    input: '<a href="http://www.google.com">12345</a>',
+    opts: { 'line-length': 5, 'line-length-ignore-regex': 'href' },
+    output: 0
+  }
+];


### PR DESCRIPTION
Can we have rule, which specifies the maximum length of a line in your html?

Options:
- **line-length** The value of this option is either `false` or a positive integer. If it is a number, the maximum length of a line in your html should not exceed that number.
- **line-length-ignore-regex** The value is either a string giving a regular expression or `false`. If set, `lines` with names matching the given regular expression are ignored for the `line-length` rule. For example, excluding lines with long `href` attributes can be done with `line-length-ignore-regex: 'href'`.

Options example:
```
{
  line-length: 80,
  line-length-ignore-regex: 'href'
}
```