### PR TITLE
Fix 'line-max-len' rule not ignoring line breaks

### DIFF
--- a/lib/rules/line-max-len.js
+++ b/lib/rules/line-max-len.js
@@ -16,7 +16,7 @@ module.exports.lint = function (line, opts) {
     return [];
   }
 
-  lineText = line.line;
+  lineText = line.line.replace(/(\r\n|\n|\r)/, '');
 
   if (ignoreRegExpString && (new RegExp(ignoreRegExpString, 'g')).test(lineText)) {
     return [];


### PR DESCRIPTION
htmllint pass line with line breaks to line rules. That fact was not considered correctly in `line-max-len` rule. Test was passed because inputs do not have line breaks.