### PR TITLE
Fix "Cannot read property 'index' of null" error in "indent-style"

### DIFF
--- a/lib/rules/indent-style.js
+++ b/lib/rules/indent-style.js
@@ -12,7 +12,9 @@ module.exports.end = function () {
 module.exports.lint = function (line, opts) {
     // The indent, that is, the whitespace characters before the first
     // non-whitespace character.
-    var indent = line.line.slice(0, /[^ \t]/.exec(line.line).index);
+    var matches = /[^ \t]/.exec(line.line);
+    var sliceEnd = matches !== null ? matches.index : line.line.length;
+    var indent = line.line.slice(0, sliceEnd);
 
     // if there are no tabs or spaces on this line, don't bother
     if (indent.length === 0) {

--- a/test/functional/indent-style.js
+++ b/test/functional/indent-style.js
@@ -72,6 +72,11 @@ module.exports = [
         ].join('\n'),
         opts: { 'indent-style': false },
         output: 0
+    }, {
+        desc: 'should work with lines containing only tabs',
+        input: '\t',
+        opts: { 'indent-style': false },
+        output: 0
     },
     {
         desc: 'indent-width should match indents with the wrong number of spaces',


### PR DESCRIPTION
htmllint throws an exception when running the following code.

```js
var lint = require('htmllint');

lint('\t'); //=> Cannot read property 'index' of null
```

This is a patch to fix the problem.
