### PR TITLE
Adds limited-top-level rule

### DIFF
--- a/lib/messages.js
+++ b/lib/messages.js
@@ -44,7 +44,7 @@ var errors = {
     E040: 'line length should not exceed <%= maxlength %> characters (current: <%= length %>)',
     E041: 'duplicate class: <%= classes %>',
     E042: 'tag is not closed',
-    E043: 'only <head> and <body> may be children of <html>
+    E043: 'only <head> and <body> may be children of <html>'
 };
 
 module.exports.errors = {};

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -43,7 +43,8 @@ var errors = {
     E039: 'lang attribute <%= lang %> in not properly capitalized',
     E040: 'line length should not exceed <%= maxlength %> characters (current: <%= length %>)',
     E041: 'duplicate class: <%= classes %>',
-    E042: 'tag is not closed'
+    E042: 'tag is not closed',
+    E043: 'only <head> and <body> may be children of <html>
 };
 
 module.exports.errors = {};

--- a/lib/options_manifest.json
+++ b/lib/options_manifest.json
@@ -79,6 +79,10 @@
         "desc": "Including a `for` attribute on label tags has the following benefits:  * improves accessibility by helping out screen readers * improves form element selection by allowing the user to give focus to an input by clicking on the label  ### Further Reading  * [MDN: label element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label) * [MDN: How to structure an HTML form](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Forms/How_to_structure_an_HTML_form)",
         "default": true
     },
+    "limited-top-level": {
+        "desc": "Only <HEAD> and <BODY> elements may be direct children of <HTML>",
+        "default": true
+    },
     "line-end-style": {
         "desc": "Line endings must conform to the given style. * \"lf\": Unix style, ending in LF. * \"crlf\": Windows style, ending in CRLF. * \"cr\": Ending in CR. * `false`: No restriction.",
         "default": "lf"

--- a/lib/options_manifest.json
+++ b/lib/options_manifest.json
@@ -81,7 +81,7 @@
     },
     "limited-top-level": {
         "desc": "Only <HEAD> and <BODY> elements may be direct children of <HTML>",
-        "default": true
+        "default": false
     },
     "line-end-style": {
         "desc": "Line endings must conform to the given style. * \"lf\": Unix style, ending in LF. * \"crlf\": Windows style, ending in CRLF. * \"cr\": Ending in CR. * `false`: No restriction.",

--- a/lib/presets/default.js
+++ b/lib/presets/default.js
@@ -40,6 +40,7 @@ module.exports = {
     'href-style': false,
     'csslint': false,
     'label-req-for': true,
+    'limited-top-level': false,
     'line-end-style': 'lf',
     'line-max-len': false,
     'line-max-len-ignore-regex': false,

--- a/lib/rules/limited-top-level.js
+++ b/lib/rules/limited-top-level.js
@@ -1,0 +1,22 @@
+var Issue = require('../issue');
+
+module.exports = {
+    name: 'limited-top-level',
+    on: ['tag'],
+    filter: ['html']
+};
+
+module.exports.lint = function (elt, opts) {
+    var output = [];
+    var legal_children = ['head', 'body'];
+
+    var illegal_children = elt.children.filter(function (e) {
+        return e.type === 'tag' && legal_children.indexOf(e.name) !== -1;
+    });
+
+    if (opts['limited-top-level'] && illegal_children.length) {
+        output.push(new Issue('E043'));
+    }
+
+    return output;
+};

--- a/lib/rules/limited-top-level.js
+++ b/lib/rules/limited-top-level.js
@@ -11,12 +11,11 @@ module.exports.lint = function (elt, opts) {
     var legal_children = ['head', 'body'];
 
     var illegal_children = elt.children.filter(function (e) {
-        return e.type === 'tag' && legal_children.indexOf(e.name) !== -1;
+        return (e.type === 'tag' && !legal_children.includes(e.name));
     });
 
     if (opts['limited-top-level'] && illegal_children.length) {
-        output.push(new Issue('E043'));
+        output.push(new Issue('E043', illegal_children[0].openLineCol));
     }
-
     return output;
 };

--- a/test/functional/limited-top-level.js
+++ b/test/functional/limited-top-level.js
@@ -1,0 +1,33 @@
+module.exports = [
+    {
+        desc: 'html-div should pass when limited-top-level set to false',
+        input: '<html><div></div></html>',
+        opts: { 'limited-top-level': false },
+        output: 0
+    }, {
+        desc: 'html-div should fail when limited-top-level set to true',
+        input: '<html><div></div></html>',
+        opts: { 'limited-top-level': true },
+        output: 1
+    }, {
+        desc: 'head should pass when no html is present',
+        input: '<head></head>',
+        opts: { 'limited-top-level': true },
+        output: 0
+    }, {
+        desc: 'html-head-body should pass',
+        input: '<html><head></head><body></body></html>',
+        opts: { 'limited-top-level': true },
+        output: 0
+    }, {
+        desc: 'html-head-div-body should fail',
+        input: '<html><head></head><div></div><body></body></html>',
+        opts: { 'limited-top-level': true },
+        output: 1
+   }, {
+        desc: 'html-head-body should pass',
+        input: '<html><head></head><body><div></div></body></html>',
+        opts: { 'limited-top-level': true },
+        output: 0
+    }
+];


### PR DESCRIPTION
I teach web development in a school using a tool called Popcode (www.popcode.org) that relies on htmllint for html validation. I'm so glad htmllint exists!

One common thing I see my students do over and over again is create elements outside of the head or body tags. While the browser can usually handle this, it's not best practice—this rule will help proactively prevent that behavior. I'm planning on writing one more rule limiting what elements can appear in the head as well.