### PR TITLE
Added ability to use regex in attribute order.

### DIFF
--- a/lib/rules/attr-order.js
+++ b/lib/rules/attr-order.js
@@ -14,20 +14,26 @@ module.exports = {
 module.exports.lint = function (element, opts) {
     var order = opts[this.name],
         attrs = element.attribs,
+        found = [],
         lastpos = 0,
         lastname,
         issues = [];
-    order.forEach(function(name) {
-        if (!attrs.hasOwnProperty(name)) return;
-        var a = attrs[name];
-        var pos = a.nameIndex;
-        if (pos > lastpos) {
-            lastpos = pos;
-            lastname = name;
-        } else {
-            issues.push(new Issue('E043', a.nameLineCol,
-                { attribute: name, previous: lastname }));
-        }
+    order.forEach(function(pattern) {
+        var r = new RegExp(pattern);
+        Object.keys(attrs).forEach(function(key) {
+            if (r.test(key) && found.indexOf(key) == -1) {
+                var a = attrs[key];
+                var pos = a.nameIndex;
+                found.push(key);
+                if (pos > lastpos) {
+                    lastpos = pos;
+                    lastname = pattern;
+                } else {
+                    issues.push(new Issue('E043', a.nameLineCol,
+                        { attribute: pattern, previous: lastname }));
+                }
+            }
+        });
     });
 
     return issues;

--- a/test/functional/attr-order.js
+++ b/test/functional/attr-order.js
@@ -34,5 +34,47 @@ module.exports = [
         input: '<img src="test.gif" class="test"></img>',
         opts: { 'attr-order': ['class','src','height','width'] },
         output: 1
+    },
+    {
+        desc: 'should pass when attribute order is consistent with regex (class then everything else)',
+        input: '<img class="test" src="test.gif" height="200" width="300"></img>',
+        opts: { 'attr-order': ['class','.*'] },
+        output: 0
+    },
+    {
+        desc: 'should fail when attribute order is not consistent with regex (class then everything else)',
+        input: '<img src="test.gif" class="test" height="200" width="300"></img>',
+        opts: { 'attr-order': ['class','.*'] },
+        output: 1
+    },
+    {
+        desc: 'should give one error per misplaced attribute with regex (class then everything else)',
+        input: '<img src="test.gif" height="200" class="test" width="300"></img>',
+        opts: { 'attr-order': ['class','.*'] },
+        output: 2
+    },
+    {
+        desc: 'should pass when attribute order is consistent with regex (class then data tags)',
+        input: '<img class="test" src="test.gif" data-x="123" data-y="456"></img>',
+        opts: { 'attr-order': ['class','data-.*'] },
+        output: 0
+    },
+    {
+        desc: 'should fail when attribute order is not consistent with regex (class then data tags)',
+        input: '<img src="test.gif" data-x="123" class="test" data-y="456"></img>',
+        opts: { 'attr-order': ['class','data-.*'] },
+        output: 1
+    },
+    {
+        desc: 'should pass when attribute order is consistent with regex (class then data tags then others)',
+        input: '<img class="test" data-x="123" data-y="456" src="test.gif"></img>',
+        opts: { 'attr-order': ['class','data-.*','.*'] },
+        output: 0
+    },
+    {
+        desc: 'should fail when attribute order is not consistent with regex (class then data tags then others)',
+        input: '<img class="test" src="test.gif" data-x="123" data-y="456"></img>',
+        opts: { 'attr-order': ['class','data-.*','.*'] },
+        output: 1
     }
 ];


### PR DESCRIPTION
I wanted to be able to specify a rule like "id" then "class" then everything else. This can be achieved by allowing regex in the attribute order array. This lends a lot of flexibility and could be useful for lots of things like "class" then "data-.*" or something along those lines.

Implementation was pretty straightforward. I first modified the existing logic to iterate over the attributes in a nested loop and check each one. Then I added regex processing of each pattern supplied instead of just names. Finally, I added a list of attributes which have already been matched by an earlier pattern in case a later regex is more general (as in "id" then "class" then everything else).

The original properties of allowing extra attributes in the tag, and allowing attributes to be missing are retained.