### PR TITLE
Differentiate error message between rules

### DIFF
--- a/lib/messages.js
+++ b/lib/messages.js
@@ -12,7 +12,7 @@ var errors = {
     E008: 'the doctype must conform to the HTML5 standard',
     E009: 'use only <%= format %> links',
     E010: 'ids and classes may not use the word "ad"',
-    E011: 'value must match the format: <%= format %>',
+    E011: '<%= attribute %> value must match the format: <%= format %>',
     E012: 'the id "<%= id %>" is already in use',
     E013: 'the `alt` property must be set for image tags',
     E014: 'a source must be given for each `img` tag',

--- a/lib/rules/class-style.js
+++ b/lib/rules/class-style.js
@@ -31,6 +31,6 @@ module.exports.lint = function (classes, opts) {
         return !(ignore_class[i] || format.test(c));
     }).map(function(c, i) {
         return new Issue('E011', classes.lineCol,
-                         { format: format.desc, 'class': c });
+                         { attribute: 'class', format: format.desc, 'class': c });
     });
 }

--- a/lib/rules/id-style.js
+++ b/lib/rules/id-style.js
@@ -39,5 +39,5 @@ module.exports.lint = function (attr, opts) {
 
     return (ignore && ignore.test(v)) || format.test(v)
         ? []
-        : new Issue('E011', attr.valueLineCol, { format: format.desc, id: v });
+        : new Issue('E011', attr.valueLineCol, { attribute: 'class', format: format.desc, id: v });
 };


### PR DESCRIPTION
Because both `class-style` and `id-style` give the error `value must match the format` but doesn't say which attribute needs to be corrected or what rule is being broken.