### PR TITLE
New rule: tag-req-attr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ npm-debug.log
 
 # phpstorm
 .idea
+
+# mac
+.DS_Store

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -55,7 +55,8 @@ var errors = {
     E051: 'invalid option or preset name: <%= name %>',
     E052: 'not a preset: <%= preset %>',
     E053: 'invalid value for option <%= rule %>: <%= value %>',
-    E054: 'option <%= name %> does not exist'
+    E054: 'option <%= name %> does not exist',
+    E055: 'tag has missing or empty attributes'
 };
 
 module.exports.errors = {};

--- a/lib/presets/default.js
+++ b/lib/presets/default.js
@@ -60,5 +60,6 @@ module.exports = {
     'input-radio-req-name': true,
     'input-req-label': false,
     'table-req-caption': false,
-    'table-req-header': false
+    'table-req-header': false,
+	'tag-req-attr': false
 };

--- a/lib/process_option.js
+++ b/lib/process_option.js
@@ -52,5 +52,8 @@ module.exports = {
 
         return regex && { desc: name, test: regex.test.bind(regex) };
     },
+    object: function (o) {
+        return Object.keys(o).length > 0 ? o : {};
+    },
     getRegExp: getRegExp
 };

--- a/lib/rules/tag-req-attr.js
+++ b/lib/rules/tag-req-attr.js
@@ -1,0 +1,33 @@
+var knife = require('../knife'),
+    Issue = require('../issue'),
+    proc = require('../process_option');
+
+module.exports = {
+    name: 'tag-req-attr',
+    on: ['tag'],
+    desc: 'If set, specified attributes should be present on the specified tag',
+	process: proc.object
+};
+
+module.exports.lint = function (element, opts) {
+	var tags = opts[this.name],
+		errorCount = 0;
+
+	for (var tagName in tags) {
+		if (tagName === element.name) {
+			var requiredAttributes = tags[tagName],
+				elementAttributes = element.attribs;
+
+			requiredAttributes.forEach(function(attribute) {
+				var elementAttribute = elementAttributes[attribute.name],
+					allowEmpty = typeof attribute.allowEmpty === 'undefined' ? false : attribute.allowEmpty;
+
+				if (typeof elementAttribute === 'undefined' || (!allowEmpty && !knife.hasNonEmptyAttr(element, attribute.name))) {
+					errorCount++;
+				}
+			});
+		}
+	}
+
+	return errorCount === 0 ? [] : new Issue('E055', element.openLineCol);
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "htmllint",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "An unofficial html5 linter.",
   "repository": {
     "type": "git",
@@ -49,5 +49,8 @@
   },
   "engines": {
     "node": ">=4"
-  }
+  },
+  "contributors": [
+	"Yannick Van Avermaet <yvanavermaet+npm@gmail.com> (https://twitter.com/yvanavermaet)"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "htmllint",
-  "version": "0.7.0",
+  "version": "0.6.0",
   "description": "An unofficial html5 linter.",
   "repository": {
     "type": "git",

--- a/test/functional/tag-req-attr.js
+++ b/test/functional/tag-req-attr.js
@@ -1,0 +1,104 @@
+module.exports = [
+    {
+        desc: 'should pass when set to false',
+        input: '<img />',
+        opts: {
+			'tag-req-attr': false
+		},
+        output: 0
+    },
+    {
+        desc: 'should pass when set to empty object',
+        input: '<img />',
+        opts: {
+			'tag-req-attr': {}
+		},
+        output: 0
+    }, {
+        desc: 'should pass when tag has correct attributes set',
+        input: '<img src="nyan.mrw" alt="nyan" />',
+        opts: {
+			'tag-req-attr': {
+				'img': [
+					{
+						'name': 'src'
+					},
+					{
+						'name': 'alt'
+					}
+				]
+			}
+		},
+        output: 0
+    }, {
+        desc: 'should fail when tag has no correct attributes set',
+        input: '<img id="notasource" />',
+		opts: {
+			'tag-req-attr': {
+				'img': [
+					{
+						'name': 'src'
+					}
+				]
+			}
+		},
+        output: 1
+    }, {
+        desc: 'should fail when tag has no correct attributes set',
+        input: '<img id="notasource" />',
+		opts: {
+			'tag-req-attr': {
+				'img': [
+					{
+						'name': 'src',
+						'allowEmpty': false
+					}
+				]
+			}
+		},
+        output: 1
+    }, {
+        desc: 'should fail when tag attribute is empty',
+        input: '<img src />',
+		opts: {
+			'tag-req-attr': {
+				'img': [
+					{
+						'name': 'src'
+					}
+				]
+			}
+		},
+        output: 1
+    }, {
+        desc: 'should pass when tag has correct attributes set',
+        input: '<img src="nyan.mrw" alt="" />',
+        opts: {
+			'tag-req-attr': {
+				'img': [
+					{
+						'name': 'src'
+					},
+					{
+						'name': 'alt',
+						'allowEmpty': true
+					}
+				]
+			}
+		},
+        output: 0
+    }, {
+        desc: 'should pass when there is no configuration for the tag',
+        input: '<img src="nyan.mrw" alt="" />',
+        opts: {
+			'tag-req-attr': {
+				'input': [
+					{
+						'name': 'type'
+					}
+				]
+			}
+		},
+        output: 0
+    }
+];


### PR DESCRIPTION
Pull request for https://github.com/htmllint/htmllint/issues/113

It's an optional rule to start with (default = false). There are some "must haves" on the web: html needs lang, img needs alt, ... but I don't think it's a good idea to "force" them. I believe we could add the previous "must haves" to a preset of some sort, but I didn't want to make it a forced list by default.

### Configurable as such:
**Rule**: tag-req-attr
**Configuration**: object with key-value mapping. Key is the name of the tag (img, div, ...), value is an array of objects. Each object, within the array must contain at least 1 key-value pair, but it may contain 2.

- First key-value pair is: Key = "name", value is the attributename.

- Second key-value pair is: Key = "allowEmpty", value is true/false. Default = false (as in: may not be empty)

### Example:
`'tag-req-attr': {
	'img': [
		{
			'name': 'src'
		},
		{
			'name': 'alt',
			'allowEmpty': true
		}
	]
}`