### PR TITLE
Add package-lock.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ site
 # node
 node_modules
 npm-debug.log
+package-lock.json
 
 # phpstorm
 .idea


### PR DESCRIPTION
@mlochbaum From you comment on the previous PR :
> I assume including package-lock.json was a mistake and have removed it.

From the npm documentation, see https://docs.npmjs.com/files/package-lock.json :
>This file is intended to be committed into source repositories, and serves various purposes


But some people choose not to do so. If that's the case, I think this file should be added to `.gitignore`