### PR TITLE
Update not to ignore line with spaces only line in indent-style

### DIFF
--- a/lib/rules/indent-style.js
+++ b/lib/rules/indent-style.js
@@ -110,7 +110,7 @@ module.exports.lint = function (line, opts) {
         }
 
         if (l % width !== 0 && !(opts['indent-width-cont'] &&
-                                 line.line[indent.length] !== '<')) {
+                                 !/[\r\n<]/.test(line.line[indent.length]))) {
             output.push(new Issue('E036', [line.row, i - l + 1],
                                     { width: width }));
         }


### PR DESCRIPTION
Hi,

I think we should still check indent for those line with spaces only when enabled `indent-width-cont`.

For example (`+` stands for space and indent width is 4):

```html
<div>
+++++
++++<input type="button" />
</div>
<script>
++var foo = 1;
</script>
```

It should has a result:
```
tests/foo.html: line 2, col 1, indenting spaces must be used in groups of 4
```