### PR TITLE
No space after attr

### DIFF
--- a/lib/rules/attr-validate.js
+++ b/lib/rules/attr-validate.js
@@ -7,7 +7,7 @@ module.exports = {
 };
 
 module.exports.lint = function (ele, opts) {
-    var attrRegex = /^\s*([^ "'>=\^]+(\s*=\s*(("[^"]*")|('[^']*')|([^ \t\n"']+)))?\s+)*$/,
+    var attrRegex = /^\s*([^ "'>=\^]+(\s*=\s*(("[^"]*")|('[^']*')|([^ \t\n"']+)))?[\/\s]+)*$/,
         open = ele.open.slice(ele.name.length);
     return attrRegex.test(open + ' ') ? [] : new Issue('E049', ele.openLineCol);
 };


### PR DESCRIPTION
No space should be required if we're using a slash.

e.g. `<meta charset="utf-8"/>` should be acceptable
but before this required `<meta src="utf-8" />`