### PR TITLE
Fix for the case when both indent-delta and indent-width-cont are enabled

### DIFF
--- a/lib/rules/indent-style.js
+++ b/lib/rules/indent-style.js
@@ -62,8 +62,10 @@ module.exports.lint = function (line, opts) {
 
     var width = opts['indent-width'];
     var deltaEnabled = opts['indent-delta'];
+    var cont = opts['indent-width-cont']
+            && !/[\r\n<]/.test(line.line[indent.length]);
 
-    if (deltaEnabled) {
+    if (deltaEnabled && !cont) {
         var currentLineIndentCount = 0,
             l = 0;
         if (width <= 1) {
@@ -96,9 +98,6 @@ module.exports.lint = function (line, opts) {
     if (indent.length === 0) {
         return output;
     }
-
-    var cont = opts['indent-width-cont']
-            && !/[\r\n<]/.test(line.line[indent.length]);
 
     if (width && !cont) {
         var i, l = 0;

--- a/test/functional/indent-delta.js
+++ b/test/functional/indent-delta.js
@@ -63,5 +63,15 @@ module.exports = [
         ].join('\n'),
         opts: { 'indent-delta':true, 'indent-width':2 },
         output: 3
+    }, {
+        desc: 'should take into account indent-width-cont option',
+        input: [
+            '<div myFirstAttr="a">',
+            '     mySecondAttr="b">',
+            '  <p>hello</p>',
+            '</div>'
+        ].join('\n'),
+        opts: { 'indent-delta':true, 'indent-width':2, 'indent-width-cont':true },
+        output: 0
     },
 ]


### PR DESCRIPTION
When both indent-delta and indent-width-cont options are enabled, I'd expect the following HTML to be correct, but it isn't as indent-delta doesn't take into account the existence of indent-width-cont.

```
<div myFirstAttr="a">
     mySecondAttr="b">
  <p>hello</p>
</div>
```
This PR fixes the problem. A test with this example is included.

@mlochbaum if merged, I'd really appreciate the release of a new version of htmllint (0.7.3) so that we can use the library in our project. Thanks! :)