### PR TITLE
Allow Fragment-Only URLs for `href-style` Rule

### DIFF
--- a/lib/rules/href-style.js
+++ b/lib/rules/href-style.js
@@ -22,6 +22,11 @@ module.exports.lint = function (element, opts) {
         return [];
     }
 
+    // Allow fragment-only URLs
+    if (attr.href.value.startsWith('#')) {
+        return [];
+    }
+
     // Link must be absolute iff specified format is absolute
     var isAbsolute = attr.href.value.search('://') !== -1;
     return (isAbsolute === (format === 'absolute'))

--- a/test/functional/href-style.js
+++ b/test/functional/href-style.js
@@ -29,5 +29,10 @@ module.exports = [
         input: '<a></a>',
         opts: { 'href-style': 'absolute' },
         output: 0
+    }, {
+        desc: 'should not match fragment-only URLs',
+        input: '<a href="#fragment"></a>',
+        opts: { 'href-style': 'absolute' },
+        output: 0
     }
 ];


### PR DESCRIPTION
### Description

Updates the `href-style` rule to allow fragment-only URLs (`href="#location"`). Issue discovered when adding the rule to the [Popcode web code editor](https://github.com/popcodeorg/popcode/issues/1608).