### PR TITLE
remove waffle.io badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # htmllint [![npm version](http://img.shields.io/npm/v/htmllint.svg?style=flat-square)](https://npmjs.org/package/htmllint) [![license](http://img.shields.io/npm/l/htmllint.svg?style=flat-square)](https://npmjs.org/package/htmllint) [![build status](http://img.shields.io/travis/htmllint/htmllint/master.svg?style=flat-square)](https://travis-ci.org/htmllint/htmllint) [![coveralls](http://img.shields.io/coveralls/htmllint/htmllint.svg?style=flat-square)](https://coveralls.io/r/htmllint/htmllint)
 
-[![stories in ready](https://badge.waffle.io/htmllint/htmllint.svg?label=ready&title=Ready)](http://waffle.io/htmllint/htmllint)
 [![dependencies](http://img.shields.io/david/htmllint/htmllint.svg?style=flat-square)](https://david-dm.org/htmllint/htmllint)
 [![devDependencies](http://img.shields.io/david/dev/htmllint/htmllint.svg?style=flat-square)](https://david-dm.org/htmllint/htmllint)
 


### PR DESCRIPTION
Removed waffle.io badge due to this service being shut down, causing the readme to have a broken link.