### PR TITLE
chore: add frame to self-closing tags list

### DIFF
--- a/lib/knife/is_void_element.js
+++ b/lib/knife/is_void_element.js
@@ -4,6 +4,7 @@ var elems = [
     'br',
     'col',
     'embed',
+    'frame',
     'hr',
     'img',
     'input',


### PR DESCRIPTION
The HTML attr `<frame />` is a self-closing tag and throws an [error](https://github.com/htmllint/htmllint/blob/master/lib/knife/relative_line_col.js#L15) when linting.  